### PR TITLE
Fix authorization problem in topic tree finder for sub sites.

### DIFF
--- a/ftw/topics/finder.py
+++ b/ftw/topics/finder.py
@@ -29,7 +29,7 @@ class DefaultTopicTreeFinder(object):
         obj = self.context
         while obj:
             if INavigationRoot.providedBy(obj) and \
-                    len(self._get_direct_topic_trees(obj)):
+                    self._has_direct_topic_trees(obj):
                 return '/'.join(obj.getPhysicalPath())
 
             if IPloneSiteRoot.providedBy(obj):
@@ -39,6 +39,9 @@ class DefaultTopicTreeFinder(object):
 
         return '/'.join(getSite().getPhysicalPath())
 
-    def _get_direct_topic_trees(self, obj):
-        return obj.listFolderContents({
-                'object_provides': ITopicTree.__identifier__})
+    def _has_direct_topic_trees(self, context):
+        for obj in context.objectValues():
+            if ITopicTree.providedBy(obj):
+                return True
+
+        return False

--- a/ftw/topics/tests/test_finder.py
+++ b/ftw/topics/tests/test_finder.py
@@ -2,8 +2,8 @@ from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from ftw.testing import MockTestCase
 from ftw.topics.finder import DefaultTopicTreeFinder
 from ftw.topics.interfaces import ITopicRootFinder
+from ftw.topics.interfaces import ITopicTree
 from ftw.topics.testing import ZCML_LAYER
-from mocker import ANY
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from zope.component import getMultiAdapter
 from zope.component import getSiteManager
@@ -33,10 +33,10 @@ class TestDefaultTopicTreeFinder(MockTestCase):
 
         if with_trees:
             objs['root'] = self.providing_stub(ITopicRootFinder)
-            self.expect(objs['site'].listFolderContents(ANY)).result([
+            self.expect(objs['site'].objectValues()).result([
                     objs['root']])
         else:
-            self.expect(objs['site'].listFolderContents(ANY)).result([])
+            self.expect(objs['site'].objectValues()).result([])
 
         objs['foo'] = self.stub()
         self.expect(objs['foo'].getPhysicalPath()).result(['', 'site', 'foo'])
@@ -53,11 +53,11 @@ class TestDefaultTopicTreeFinder(MockTestCase):
         self.set_parent(objs['bar'], objs['subsite'])
 
         if with_trees:
-            objs['subtree'] = self.providing_stub(ITopicRootFinder)
-            self.expect(objs['subsite'].listFolderContents(ANY)).result([
+            objs['subtree'] = self.providing_stub(ITopicTree)
+            self.expect(objs['subsite'].objectValues()).result([
                     objs['subtree']])
         else:
-            self.expect(objs['subsite'].listFolderContents(ANY)).result([])
+            self.expect(objs['subsite'].objectValues()).result([])
 
         return objs
 


### PR DESCRIPTION
The schema extender is always anonymous.
Using listFolderContents takes authorization in account, resulting in that not published
topic trees are never visible for anyone and therefore the subsite topics are not selectable
when there are no trees in the subsite yet published.

Therefore the check for trees in subsite should not be security dependent, using objectValues now.

/cc @maethu 
