### PR TITLE
Make backreferences hideable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added option to hide backreferences in topics.
+  [lknoefpel]
 
 
 1.1.1 (2014-02-28)

--- a/ftw/topics/browser/templates/topic_listing.pt
+++ b/ftw/topics/browser/templates/topic_listing.pt
@@ -6,7 +6,7 @@
     i18n:domain="ftw.topics">
 
     <div class="topic-filter"
-         tal:condition="view/display_section_headings">
+         tal:condition="python: view.display_section_headings() and context.show_backrefs">
 
         <h2 i18n:translate="label_topic_section">Section</h2>
         <ul>
@@ -23,7 +23,8 @@
 
     </div>
 
-    <div class="topic-reference-listings">
+    <div class="topic-reference-listings"
+         tal:condition="context/show_backrefs">
         <tal:REPRESENTATION repeat="adapter view/representations">
             <tal:avialble condition="adapter/available">
                 <h2 class="referenceRepresentationTitle"

--- a/ftw/topics/contents/topic.py
+++ b/ftw/topics/contents/topic.py
@@ -1,11 +1,18 @@
+from ftw.topics import _
 from ftw.topics.interfaces import ITopic
 from plone.dexterity.content import Container
 from plone.directives.form import Schema
+from zope import schema
 from zope.interface import implements
 
 
 class ITopicSchema(Schema):
-    pass
+
+    show_backrefs = schema.Bool(
+        title=_(u"Show backreferences"),
+        default=True,
+        required=False
+        )
 
 
 class Topic(Container):

--- a/ftw/topics/locales/de/LC_MESSAGES/ftw.topics.po
+++ b/ftw/topics/locales/de/LC_MESSAGES/ftw.topics.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-05-15 06:58+0000\n"
+"POT-Creation-Date: 2014-11-27 10:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,7 +10,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
+
+#: ./ftw/topics/contents/topic.py:12
+msgid "Show backreferences"
+msgstr "Zeige verlinkte Inhalte"
 
 #: ./ftw/topics/profiles/default/types/ftw.topics.Topic.xml
 msgid "Topic"
@@ -20,7 +23,7 @@ msgstr "Thema"
 msgid "Topic Tree"
 msgstr "Themenbaum"
 
-#: ./ftw/topics/browser/templates/topic_listing.pt:39
+#: ./ftw/topics/browser/templates/topic_listing.pt:40
 msgid "Topics"
 msgstr "Themen"
 
@@ -46,6 +49,8 @@ msgstr "Themenkatalog:"
 
 #. Default: "Topics"
 #: ./ftw/topics/behavior.py:39
-#: ./ftw/topics/extender.py:42
+#: ./ftw/topics/extender.py:43
 msgid "label_topics"
 msgstr "Themen"
+
+

--- a/ftw/topics/locales/ftw.topics.pot
+++ b/ftw/topics/locales/ftw.topics.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-05-15 06:58+0000\n"
+"POT-Creation-Date: 2014-11-27 10:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,10 +12,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.topics\n"
+
+#: ./ftw/topics/contents/topic.py:12
+msgid "Show backreferences"
+msgstr ""
 
 #: ./ftw/topics/profiles/default/types/ftw.topics.Topic.xml
 msgid "Topic"
@@ -25,7 +26,7 @@ msgstr ""
 msgid "Topic Tree"
 msgstr ""
 
-#: ./ftw/topics/browser/templates/topic_listing.pt:39
+#: ./ftw/topics/browser/templates/topic_listing.pt:40
 msgid "Topics"
 msgstr ""
 
@@ -51,7 +52,8 @@ msgstr ""
 
 #. Default: "Topics"
 #: ./ftw/topics/behavior.py:39
-#: ./ftw/topics/extender.py:42
+#: ./ftw/topics/extender.py:43
 msgid "label_topics"
 msgstr ""
+
 

--- a/ftw/topics/tests/test_topic_view.py
+++ b/ftw/topics/tests/test_topic_view.py
@@ -1,15 +1,18 @@
-from Products.CMFCore.utils import getToolByName
+from ftw.testbrowser import browsing
 from ftw.topics.testing import EXAMPLE_CONTENT_DEFAULT_FUNCTIONAL
 from ftw.topics.testing import EXAMPLE_CONTENT_SIMPLELAYOUT_FUNCTIONAL
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import login
-from plone.app.testing import setRoles
 from plone.browserlayer.layer import mark_layer
 from plone.mocktestcase.dummy import Dummy
 from plone.testing.z2 import Browser
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from pyquery import PyQuery
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
@@ -211,6 +214,18 @@ class TestDefaultTopicView(TestCase):
         self.topicview()
         reference_titles = [v['title'] for v in self.topicview.objects]
         self.assertEquals(references, reference_titles)
+
+    @browsing
+    def test_settings_can_hide_backreferences(self, browser):
+        browser.login(username=SITE_OWNER_NAME, password=SITE_OWNER_PASSWORD)
+
+        browser.visit(self.topic_technology)
+        self.assertTrue(browser.css('.referenceRepresentationListing'))
+
+        browser.visit(self.topic_technology, view='edit')
+        browser.fill({'Show backreferences': False}).submit()
+
+        self.assertFalse(browser.css('.referenceRepresentationListing'))
 
 
 class TestSimplelayoutTopicView(TestDefaultTopicView):


### PR DESCRIPTION
Added `boolean` field "Show backreferences". Default: `True`
# Screenshots

Default state "Show backreferences" checked. Like before.
![screen shot 2014-11-27 at 12 00 29](https://cloud.githubusercontent.com/assets/1375745/5215979/4c751d60-762d-11e4-99e2-f1c6c9c89708.png)

Edit form.
![screen shot 2014-11-27 at 12 01 16](https://cloud.githubusercontent.com/assets/1375745/5215987/5924fe4a-762d-11e4-8a15-28b52661e990.png)

Disabled.
![screen shot 2014-11-27 at 12 01 25](https://cloud.githubusercontent.com/assets/1375745/5215989/65de3462-762d-11e4-9770-b12ab200e332.png)

@maethu 
