### PR TITLE
Restrict versions of some dependencies so they don't pull in Plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- Restrict versions of some dependencies so they don't pull in Plone 5.
+  [mbaechtold]
+
 - Also enable navigation behavior on ftw.topic.Topics.
   [mathias.leimgruber]
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ setup(name='ftw.topics',
         'plone.dexterity',
         'plone.app.dexterity',
         'collective.dexteritytextindexer',
+        'collective.geo.openlayers >= 3.0, < 4.0',
+        'collective.geo.mapwidget >= 2.1, < 3.0',
         'plone.app.referenceablebehavior',
         'plone.directives.form',
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,11 +3,4 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
-# c.geo.mapwidget is incompatible with geopy >= 0.96
-# see https://github.com/collective/collective.geo.mapwidget/commit/81dfd91e666585c7a413f986ac9b5a8cee328cd4
-    collective.geo.mapwidget
-
-# c.geo.mapwidget master depends on c.geo.openlayers > 3.0, which hasn't been released yet
-    collective.geo.openlayers
-
     ftw.testing


### PR DESCRIPTION
This fixes the failing tests on our internal continuous integration server.