### PR TITLE
Exclude expired and future content from the collected backreferences.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Exclude expired and future content from the collected backreferences. [elioschmutz]
 
 
 1.3.0 (2018-07-04)

--- a/ftw/topics/tests/test_collector.py
+++ b/ftw/topics/tests/test_collector.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from ftw.topics.interfaces import IBackReferenceCollector
 from ftw.topics.testing import EXAMPLE_CONTENT_DEFAULT_FUNCTIONAL
 from plone.uuid.interfaces import IUUID
@@ -164,3 +165,25 @@ class TestDefaultCollector(TestCase):
         result = comp._get_similar_topic_objects()
         self.assertIn(self.node, result)
         self.assertIn(self.subsite_node, result)
+
+    def test_exclude_expired_content(self):
+        comp = getMultiAdapter((self.node, None),
+                               IBackReferenceCollector)
+
+        self.assertIn(self.doc, comp._get_merged_brefs())
+
+        self.doc.setExpirationDate(DateTime() - 10)
+        self.doc.reindexObject()
+
+        self.assertNotIn(self.doc, comp._get_merged_brefs())
+
+    def test_exclude_future_content(self):
+        comp = getMultiAdapter((self.node, None),
+                               IBackReferenceCollector)
+
+        self.assertIn(self.doc, comp._get_merged_brefs())
+
+        self.doc.setEffectiveDate(DateTime() + 10)
+        self.doc.reindexObject()
+
+        self.assertNotIn(self.doc, comp._get_merged_brefs())


### PR DESCRIPTION
Before:

<img width="1030" alt="Bildschirmfoto 2019-06-12 um 12 45 30" src="https://user-images.githubusercontent.com/557005/59345707-fae7d000-8d10-11e9-8d20-a5613dcb1734.png">

After:

<img width="1055" alt="Bildschirmfoto 2019-06-12 um 12 46 43" src="https://user-images.githubusercontent.com/557005/59345709-fcb19380-8d10-11e9-9da9-0fb170473e6e.png">

closes #24 
