### PR TITLE
Testing content: do not reuse an ID which is existing as an uncle.

### DIFF
--- a/ftw/topics/tests/profiles/example/content_creation/11_sub_topic_tree.json
+++ b/ftw/topics/tests/profiles/example/content_creation/11_sub_topic_tree.json
@@ -1,6 +1,6 @@
 [
 
-    {"_path": "foo/subsite/topics",
+    {"_path": "foo/subsite/topics1",
      "_type": "ftw.topics.TopicTree",
      "title": "Topics",
      "_children": [

--- a/ftw/topics/tests/profiles/example/content_creation/12_sub_content.json
+++ b/ftw/topics/tests/profiles/example/content_creation/12_sub_content.json
@@ -3,11 +3,11 @@
     {"_path": "foo/subsite/theories",
      "_type": "Document",
      "title": "Theories",
-     "topics": ["resolvePath::/foo/subsite/topics/manufacturing"]},
+     "topics": ["resolvePath::/foo/subsite/topics1/manufacturing"]},
 
     {"_path": "foo/subsite/manufactors",
      "_type": "Document",
      "title": "Manufactors",
-     "topics": ["resolvePath::/foo/subsite/topics/manufacturing/agile-manufacturing"]}
+     "topics": ["resolvePath::/foo/subsite/topics1/manufacturing/agile-manufacturing"]}
 
 ]

--- a/ftw/topics/tests/test_collector.py
+++ b/ftw/topics/tests/test_collector.py
@@ -21,7 +21,7 @@ class TestDefaultCollector(TestCase):
 
         self.tree = self.portal.get('topics')
         self.node = self.tree.get('manufacturing')
-        self.subsite_tree = self.subsite.get('topics')
+        self.subsite_tree = self.subsite.get('topics1')
         self.subsite_node = self.subsite_tree.get('manufacturing')
 
         self.doc = self.portal.get('manufacturing-processes')

--- a/ftw/topics/tests/test_topic_view.py
+++ b/ftw/topics/tests/test_topic_view.py
@@ -31,7 +31,7 @@ class TestDefaultTopicView(TestCase):
         self.subnode = self.node.get('agile-manufacturing')
         self.topic_technology = self.tree.get('technology')
 
-        self.subsite_tree = self.subsite.get('topics')
+        self.subsite_tree = self.subsite.get('topics1')
         self.subsite_node = self.subsite_tree.get('manufacturing')
 
         transaction.commit()


### PR DESCRIPTION
Using an ID for a content which is already in use by a child of a parent can cause problems such as when setting relations. Therefore the topic tree in the subsite must have another name than the root topic tree.

This fixes the test setup. The test failures can be fixed in the `plone5` branch.