### PR TITLE
Make collector more robust if there is a non DX object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make collector more robust if there is a non DX object. [mathias.leimgruber]
 
 
 2.1.0 (2020-01-09)

--- a/ftw/topics/collector.py
+++ b/ftw/topics/collector.py
@@ -148,6 +148,7 @@ class DefaultCollector(object):
         return map(attrgetter('from_object'), relations)
 
     def _filter_inactive_content(self, obj):
+        effective_date, expiration_date = None, None
         if IDexterityContent.providedBy(obj):
             effective_date, expiration_date = self._get_dx_publication_dates(obj)
 


### PR DESCRIPTION
This prevents a "UnboundLocalError" error